### PR TITLE
Static version of the collections navigation bar

### DIFF
--- a/app/assets/stylesheets/ecosystems.scss
+++ b/app/assets/stylesheets/ecosystems.scss
@@ -1227,3 +1227,20 @@ body {
   }
 }
 
+.dboard-collection-bar {
+  .container {
+    border-bottom: 3px solid $color-purple;
+  }
+
+}
+
+a.project-badge {
+  &:hover,
+  &:active,
+  &:focus {
+    color: $color-white !important;
+    background-color: $color-purple !important;
+    text-decoration: none;
+  }
+}
+

--- a/app/views/projects/_project_header.erb
+++ b/app/views/projects/_project_header.erb
@@ -15,3 +15,35 @@
     </div>
   </div>
 </div>
+<div class="dboard-collection-bar mb-5">
+  <div class="container pb-4">
+    <h2 class="h4 mb-3">Showing</h2>
+    <div class="row">
+      <div class="col">
+        <span class="project-badge badge text-bg-light d-inline-flex align-items-center align-middle py-2 px-3 me-2 mb-2">
+          <img src="https://github.com/octobox.png" height="24" width="24" class="me-2"/> 
+          Octobox
+        </span>
+        <span class="project-badge badge text-bg-light d-inline-flex align-items-center align-middle py-2 px-3 me-2 mb-2">
+          <img src="https://github.com/octobox.png" height="24" width="24" class="me-2"/> 
+          Octobox
+        </span>
+        <span class="project-badge badge text-bg-light d-inline-flex align-items-center align-middle py-2 px-3 me-2 mb-2">
+          <img src="https://github.com/octobox.png" height="24" width="24" class="me-2"/> 
+          Octobox
+        </span>
+        <span class="project-badge badge text-bg-light d-inline-flex align-items-center align-middle py-2 px-3 me-2 mb-2">
+          <img src="https://github.com/octobox.png" height="24" width="24" class="me-2"/> 
+          Octobox
+        </span>
+        <span class="project-badge badge text-bg-light d-inline-flex align-items-center align-middle py-2 px-3 me-2 mb-2" >
+          <img src="https://github.com/octobox.png" height="24" width="24" class="me-2"/> 
+          Octobox
+        </span>
+        <a href="#" class="project-badge badge text-bg-light d-inline-flex align-items-center align-middle py-2 px-3 me-2 mb-2" style="min-height: 40px">
+          and 253 more&hellip;
+        </a>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Adds a static version of a collections bar, needs wiring up proper

![image](https://github.com/user-attachments/assets/55b1f9c0-5e1c-4477-907e-68e4ebeb84b3)
