### PR TITLE
Disallow previous_month/previous_year comparison params in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+Disallow: /*?*previous_month=
+Disallow: /*?*previous_year=


### PR DESCRIPTION
The month/year comparison views on `/projects` and `/collections` generate a distinct URL for every `month` × `year` × `previous_month` × `previous_year` combination. bingbot has crawled 8,277 variants in the last week and the set grows on every visit.

This adds two `Disallow` lines so crawlers index the base `?month=&year=` views but skip the combinatorial comparison URLs. Google and Bing both support `*` wildcards in `Disallow` paths.